### PR TITLE
Fix image paths for case-sensitive filesystems

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,9 @@
     "version": "1.2.6",
     "description": "The tool for finding shortcuts over difficult terrain.",
     "icons": {
-        "16": "/images/icon16.png",
-        "48": "/images/icon48.png",
-        "128": "/images/icon128.png"
+        "16": "/images/Icon16.png",
+        "48": "/images/Icon48.png",
+        "128": "/images/Icon128.png"
     },
     "browser_action": {
         "default_popup": "popup.html"


### PR DESCRIPTION
* Some file systems can be case-sensitive which results in the application failing validation.